### PR TITLE
0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.3.2 / ####-##-##
 ==================
 
+  * browser.attribute method
   * browser.click and browser.clickText throws if no element is found, return the number of elements
   * Puppeteer settings are now passed down in createBrowser, including slowMo
   * Minor improvements in assertion messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.3.2 / ####-##-##
 ==================
 
+  * Attribute and not attribute assertions
   * browser.attribute method
   * browser.click and browser.clickText throws if no element is found, return the number of elements
   * Puppeteer settings are now passed down in createBrowser, including slowMo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.3.2 / ####-##-##
+0.3.2 / 2018-02-16
 ==================
 
   * Attribute and not attribute assertions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 0.3.2 / ####-##-##
 ==================
 
+  * browser.click and browser.clickText throws if no element is found, return the number of elements
   * Puppeteer settings are now passed down in createBrowser, including slowMo
+  * Minor improvements in assertion messages
 
 0.3.1 / 2018-02-09
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+0.3.2 / ####-##-##
+==================
+
+  * Puppeteer settings are now passed down in createBrowser, including slowMo
+
 0.3.1 / 2018-02-09
 ==================
 
   * Method browser.clickText
   * Find by text fixed to return valid html elements
-
 
 0.3.0 / 2018-02-07
 ==================

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ await browser.assert.text("p", "My First Paragraph");
 Asserts that at least one element matching the given selector contains the expected text.
 
 ```js
-await browser.assert.text("p", "My First");
+await browser.assert.textContains("p", "My First");
 ```
 
 **title(expected, msg)**   
@@ -307,7 +307,19 @@ browser.assert.elements("p.second", {atLeast: 1}); // Ok
 ```
 
 **attribute(selector, attribute, expected, msg)**
-> TO DO
+Asserts that the first element matching the given selector contains an attribute matching the expected value. If no expected value is given, any not null value for the attribute will pass.
+
+```js
+browser.assert.attribute(".hidden-class", "class", "hidden-class");
+browser.assert.attribute(".hidden-class", "hidden");
+```
+
+To pass a custom message without specifying an expected value, you can pass null:
+```js
+browser.assert.attribute(".hidden-class", "hidden", null, "hidden-class doesn't have attribute hidden");
+```
+
+If the element doesn't exists, the assertion will fail.
 
 ### Negative assertions
 Most of the browser assertions have a negative version that can be used with `browser.assert.not`. Most of the behaviours of the "not" assertions are simply the inverse of the positive version.
@@ -325,7 +337,7 @@ Asserts that the first element with given selector is not visible. If no element
 **not.text(selector, expected, msg)**   
 Asserts that no element matching the given selector matches the expected text.
 
-```
+```js
 await browser.assert.not.text("p", "This text doesn't exists");
 ```
 
@@ -339,7 +351,18 @@ Asserts that the url of the page doesn't match the expected string.
 Asserts that the first element with the given selector doesn't have the expected value.
 
 **not.attribute(selector, attribute, expected, msg)**
-> TO DO
+Asserts that the first element matching the given selector doesn't contain an attribute with the expected value. If no expected value is given, any not null value on the attribute will fail.
+
+```js
+browser.assert.not.attribute(".not-hidden-class", "class", "hidden-class");
+browser.assert.not.attribute(".not-hidden-class", "hidden");
+```
+
+To pass a custom message without specifying an expected value, you can pass null:
+```js
+browser.assert.not.attribute(".hidden-class", "href", null, "hidden-class has attribute href");
+```
+If the element doesn't exists, the assertion will fail.
 
 ## Examples
 
@@ -384,7 +407,7 @@ describe("My Tests", function() {
 ### Running Tests With Travis CI
 Running tests using puppeteer's require disabling the sandbox running mode. This can easily be achieved by passing the environment variable `NO_SANDBOX=true`, this can be done either as part of the test execution command, as a Travis secret env variable or in the `.travis.yml` file itself:
 
-```ỳml
+```yml
 language: node_js
 os:
     - linux

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Will create and return a [Browser](#Browser) instance. It will automatically lau
         * `headless: true`: If true, the browser will run on headless mode.
         * `slowMo: 0`: Slows the execution of commands by given number of milliseconds
 
-> **Warning:** the settings will only take effect the first time a browser page is created, to fully restart the settings you must close the browser connection using `Wendigo.stop()` before executing createBrowser again 
+> **Warning:** the settings will only take effect the first time a browser page is created, to fully restart the settings you must close the browser connection using `Wendigo.stop()` before executing createBrowser again
 
 Example:
 ```js
@@ -143,7 +143,18 @@ const classes=await browser.class(node); // Returns ["container", "main", "anoth
 Returns the value of the first element with given selector. Returns _null_ if no element or value found.
 
 ```js
-const value=await browser.value("input.my-input");
+const value = await browser.value("input.my-input");
+```
+
+**attribute(selector, attributeName)**
+Return the attribute value of the first element found with given selector. Throws if no element is found. Returns `""` if the attribute is set but no value is given and `null` if the attribute doesn't exists.
+
+```js
+const classAttribute = await browser.attribute(".my-element", "class"); // Returns "my-element another-class"
+
+const hiddentAttr = await browser.attribute(".my-hidden-element", "hidden"); // Returns ""
+const hiddentAttr2 = await browser.attribute(".not-hidden-element", "hidden"); // Returns null
+
 ```
 
 **text(selector)**   

--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ Will create and return a [Browser](#Browser) instance. It will automatically lau
 
 * _settings_ is an optional object with the settings to build the browser
     * `log: false`: If true, it will log all the console events of the browser.
-    * `headless: true`: If true, the browser will run on headless mode.
+    * Any settings that can be passed to puppeteer can be passed in createdBrowser, for example:
+        * `headless: true`: If true, the browser will run on headless mode.
+        * `slowMo: 0`: Slows the execution of commands by given number of milliseconds
+
+> **Warning:** the settings will only take effect the first time a browser page is created, to fully restart the settings you must close the browser connection using `Wendigo.stop()` before executing createBrowser again 
 
 Example:
 ```js

--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ browser.assert.elements("p.second", 2); // Fails
 browser.assert.elements("p.second", {atLeast: 1}); // Ok
 ```
 
+**attribute(selector, attribute, expected, msg)**
+> TO DO
 
 ### Negative assertions
 Most of the browser assertions have a negative version that can be used with `browser.assert.not`. Most of the behaviours of the "not" assertions are simply the inverse of the positive version.
@@ -336,6 +338,8 @@ Asserts that the url of the page doesn't match the expected string.
 **not.value(selector, expected, msg)**
 Asserts that the first element with the given selector doesn't have the expected value.
 
+**not.attribute(selector, attribute, expected, msg)**
+> TO DO
 
 ## Examples
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -45,15 +45,20 @@ module.exports = class Browser extends BrowserBase {
                 if(index > elements.length || index < 0) {
                     return Promise.reject(new Error(`browser.click, invalid index "${index}" for selector "${selector}", ${elements.length} elements found.`));
                 }
-                return elements[index].click();
+                elements[index].click();
+                return 1;
             } else{
-                return Promise.all(elements.map((e) => e.click()));
+                if(elements.length <= 0) return Promise.reject(new Error(`No element "${selector}" found when trying to click.`));
+                return Promise.all(elements.map((e) => e.click())).then(() => {
+                    return elements.length;
+                });
             }
         });
     }
 
     clickText(text) {
         return this.findByText(text).then((elements) => {
+            if(elements.length <= 0) return Promise.reject(new Error(`No element with text "${text}" found when trying to click.`));
             return this.click(elements);
         });
     }
@@ -81,7 +86,9 @@ module.exports = class Browser extends BrowserBase {
     }
 
     waitFor(selector, timeout = 500) {
-        return this.frame.waitForSelector(selector, {timeout: timeout});
+        return this.frame.waitForSelector(selector, {timeout: timeout}).catch(() => {
+            return Promise.reject(new Error(`Waiting for element "${selector}" failed, timeout of ${timeout}ms exceeded`));
+        });
     }
 
     findByText(text) {

--- a/lib/browser_assertions.js
+++ b/lib/browser_assertions.js
@@ -10,7 +10,7 @@ module.exports = class BrowserAssertions {
 
     constructor(browser) {
         this._browser = browser;
-        this.not = new BrowserNotAssertions(this);
+        this.not = new BrowserNotAssertions(this, browser);
     }
 
     exists(selector, msg) {

--- a/lib/browser_assertions.js
+++ b/lib/browser_assertions.js
@@ -4,6 +4,7 @@
 const assert = require('assert');
 const BrowserNotAssertions = require('./browser_not_assertions');
 const elementsAssertionUtils = require('./assertions_utils/assert_elements');
+const utils = require('./utils');
 
 module.exports = class BrowserAssertions {
 
@@ -45,7 +46,7 @@ module.exports = class BrowserAssertions {
                 const foundText = texts.length === 0 ? "no text" : `"${texts.join(" ")}"`;
                 msg = `Expected element "${selector}" to contain text "${expected}", ${foundText} found`;
             }
-            for(const text of texts){
+            for(const text of texts) {
                 if(text && text.includes(expected)) return Promise.resolve();
             }
             assert(false, msg);
@@ -103,5 +104,26 @@ module.exports = class BrowserAssertions {
         });
     }
 
-
+    attribute(selector, attribute, expectedValue, msg) {
+        return this._browser.attribute(selector, attribute).then((value) => {
+            if(expectedValue === undefined || expectedValue === null) {
+                if(!msg) msg = `Expected element "${selector}" to have attribute "${attribute}".`;
+                assert((value !== null), msg);
+            } else {
+                if(!msg) {
+                    msg = `Expected element "${selector}" to have attribute "${attribute}" with value "${expectedValue}"`;
+                    if(value) msg = `${msg}, "${value}" found.`;
+                    else msg = `${msg}.`;
+                }
+                assert.strictEqual(value, expectedValue, msg);
+            }
+        }).catch(() => {
+            if(!msg) {
+                msg = `Expected element "${selector}" to have attribute "${attribute}"`;
+                if(expectedValue !== undefined) msg = `${msg} with value "${expectedValue}"`;
+                msg = `${msg}, no element found.`;
+            }
+            return utils.rejectAssertion(msg);
+        });
+    }
 };

--- a/lib/browser_base.js
+++ b/lib/browser_base.js
@@ -47,4 +47,14 @@ module.exports = class BrowserBase {
             else return element.value;
         }, selector);
     }
+
+    attribute(selector, attributeName) {
+        return this.page.evaluate((q, attributeName) => {
+            const element = WendigoUtils.queryElement(q);
+            if(!element) return Promise.reject();
+            return element.getAttribute(attributeName);
+        }, selector, attributeName).catch(() => {
+            return Promise.reject(new Error(`Element "${selector}" not found when trying to get attribute "${attributeName}".`));
+        });
+    }
 };

--- a/lib/browser_not_assertions.js
+++ b/lib/browser_not_assertions.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const assert = require('assert');
+const utils = require('./utils');
 
 function invertify(cb, msg) {
     return cb().then(() => {
@@ -12,8 +13,9 @@ function invertify(cb, msg) {
 
 module.exports = class BrowserAssertions {
 
-    constructor(browserAssertions) {
+    constructor(browserAssertions, browser) {
         this._assertions = browserAssertions;
+        this._browser = browser;
     }
 
 
@@ -67,7 +69,23 @@ module.exports = class BrowserAssertions {
     }
 
     attribute(selector, attribute, expectedValue, msg) {
-
+        return this._browser.attribute(selector, attribute).then((value) => {
+            if(expectedValue === undefined || expectedValue === null) {
+                if(!msg) msg = `Expected element "${selector}" not to have attribute "${attribute}".`;
+                assert((value === null), msg);
+            } else {
+                if(!msg) {
+                    msg = `Expected element "${selector}" not to have attribute "${attribute}" with value "${expectedValue}".`;
+                }
+                assert(value !== expectedValue, msg);
+            }
+        }).catch(() => {
+            if(!msg) {
+                msg = `Expected element "${selector}" not to have attribute "${attribute}"`;
+                if(expectedValue !== undefined) msg = `${msg} with value "${expectedValue}"`;
+                msg = `${msg}, no element found.`;
+            }
+            return utils.rejectAssertion(msg);
+        });
     }
-
 };

--- a/lib/browser_not_assertions.js
+++ b/lib/browser_not_assertions.js
@@ -66,4 +66,8 @@ module.exports = class BrowserAssertions {
         }, msg);
     }
 
+    attribute(selector, attribute, expectedValue, msg) {
+
+    }
+
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,12 @@
 "use strict";
 
+const assert = require('assert');
+
 module.exports = {
     isNumber(n) {
         return !Number.isNaN(Number(n));
+    },
+    rejectAssertion(msg) {
+        return Promise.reject(new assert.AssertionError({message: msg}));
     }
-
 };

--- a/lib/wendigo.js
+++ b/lib/wendigo.js
@@ -7,7 +7,9 @@ const puppeteer = require('puppeteer');
 
 const defaultSettings = {
     log: false,
-    headless: true
+    headless: true,
+    args: [],
+    slowMo: 0
 };
 
 module.exports = class Wendigo {
@@ -27,11 +29,10 @@ module.exports = class Wendigo {
     }
 
     static async _setInstance(settings) {
-        let args = [];
         if(process.env["NO_SANDBOX"]) {
-            args = ['--no-sandbox', '--disable-setuid-sandbox']; // Required to run in travis
+            settings.args = settings.args.concat(['--no-sandbox', '--disable-setuid-sandbox']); // Required to run in travis
         }
-        if(!this.instance) this.instance = await puppeteer.launch({headless: settings.headless, args: args});
+        if(!this.instance) this.instance = await puppeteer.launch(settings);
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendigo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A proper monster for front-end testing",
   "engines": {
     "node": ">=8.9.4"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "lib/wendigo.js",
   "scripts": {
-    "test": "mocha tests"
+    "test": "mocha tests --recursive"
   },
   "repository": {
     "type": "git",

--- a/tests/assertions/assert_attribute.test.js
+++ b/tests/assertions/assert_attribute.test.js
@@ -4,7 +4,7 @@ const Wendigo = require('../../lib/wendigo');
 const utils = require('../utils');
 const configUrls = require('../config.json').urls;
 
-describe.only("Assert Attribute", function() {
+describe("Assert Attribute", function() {
     this.timeout(5000);
     let browser;
 
@@ -97,7 +97,7 @@ describe.only("Assert Attribute", function() {
         await browser.open(configUrls.index);
         await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.attribute(".not-element", "hidden");
-        }, `Expected element ".hidden-text" not to have attribute "hidden". Element not found`);
+        }, `Expected element ".not-element" not to have attribute "hidden", no element found.`);
     });
 
     it("Not Attribute From Node", async() => {
@@ -112,7 +112,7 @@ describe.only("Assert Attribute", function() {
             await browser.assert.not.attribute(".hidden-text", "class", "hidden-text", "custom msg");
         }, `custom msg`);
         await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.not.attribute(".hidden-text", "hidden", "custom msg 2");
+            await browser.assert.not.attribute(".hidden-text", "hidden", null, "custom msg 2");
         }, `custom msg 2`);
     });
 });

--- a/tests/assertions/assert_attribute.test.js
+++ b/tests/assertions/assert_attribute.test.js
@@ -4,7 +4,7 @@ const Wendigo = require('../../lib/wendigo');
 const utils = require('../utils');
 const configUrls = require('../config.json').urls;
 
-describe.skip("Assert Attribute", function() {
+describe.only("Assert Attribute", function() {
     this.timeout(5000);
     let browser;
 
@@ -20,6 +20,11 @@ describe.skip("Assert Attribute", function() {
         await browser.open(configUrls.index);
         await browser.assert.attribute(".hidden-text", "class", "hidden-text");
         await browser.assert.attribute(".hidden-text", "hidden", "");
+    });
+
+    it("Attribute Without Expected", async() => {
+        await browser.open(configUrls.index);
+        await browser.assert.attribute(".hidden-text", "class");
         await browser.assert.attribute(".hidden-text", "hidden");
     });
 
@@ -34,7 +39,7 @@ describe.skip("Assert Attribute", function() {
         await browser.open(configUrls.index);
         await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.attribute(".hidden-text", "class", "hidden");
-        }, `Expected element ".hidden-text" to have attribute "class" with value "hidden". "hidden-text" found`);
+        }, `Expected element ".hidden-text" to have attribute "class" with value "hidden", "hidden-text" found.`);
 
         await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.attribute(".second-element", "hidden");
@@ -45,8 +50,8 @@ describe.skip("Assert Attribute", function() {
         await browser.open(configUrls.index);
 
         await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.attribute(".not-and-element", "class", "hidden");
-        }, `Expected element ".not-and-element" to have attribute "class" with value "hidden". No element found`);
+            await browser.assert.attribute(".not-an-element", "class", "hidden");
+        }, `Expected element ".not-an-element" to have attribute "class" with value "hidden", no element found.`);
     });
 
     it("Attribute Throws With Custom Message", async() => {
@@ -55,6 +60,59 @@ describe.skip("Assert Attribute", function() {
         await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.attribute(".hidden-text", "class", "hidden", "attribute error");
         }, `attribute error`);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.attribute(".hidden-text", "href", null, "attribute error 2");
+        }, `attribute error 2`);
     });
 
+    it("Not Attribute", async() => {
+        await browser.open(configUrls.index);
+        await browser.assert.not.attribute(".hidden-text", "class", "not-hidden-text");
+        await browser.assert.not.attribute(".hidden-text", "hidden", "something");
+    });
+
+    it("Not Attribute Without Value", async() => {
+        await browser.open(configUrls.index);
+        await browser.assert.not.attribute(".hidden-text", "href");
+    });
+
+    it("Not Attribute Throws", async() => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".hidden-text", "class", "hidden-text");
+        }, `Expected element ".hidden-text" not to have attribute "class" with value "hidden-text".`);
+    });
+
+    it("Not Attribute Without Value Throws", async() => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".hidden-text", "hidden");
+        }, `Expected element ".hidden-text" not to have attribute "hidden".`);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".hidden-text", "class");
+        }, `Expected element ".hidden-text" not to have attribute "class".`);
+    });
+
+    it("Not Attribute With No Element Found Throws", async() => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".not-element", "hidden");
+        }, `Expected element ".hidden-text" not to have attribute "hidden". Element not found`);
+    });
+
+    it("Not Attribute From Node", async() => {
+        await browser.open(configUrls.index);
+        const node = await browser.query(".hidden-text");
+        await browser.assert.not.attribute(node, "class", "not-hidden-text");
+    });
+
+    it("Not Attribute Throws Custom Message", async () => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".hidden-text", "class", "hidden-text", "custom msg");
+        }, `custom msg`);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.attribute(".hidden-text", "hidden", "custom msg 2");
+        }, `custom msg 2`);
+    });
 });

--- a/tests/assertions/assert_attribute.test.js
+++ b/tests/assertions/assert_attribute.test.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const Wendigo = require('../../lib/wendigo');
+const utils = require('../utils');
+const configUrls = require('../config.json').urls;
+
+describe.skip("Assert Attribute", function() {
+    this.timeout(5000);
+    let browser;
+
+    before(async () => {
+        browser = await Wendigo.createBrowser();
+    });
+
+    after(async() => {
+        await browser.close();
+    });
+
+    it("Attribute", async() => {
+        await browser.open(configUrls.index);
+        await browser.assert.attribute(".hidden-text", "class", "hidden-text");
+        await browser.assert.attribute(".hidden-text", "hidden", "");
+        await browser.assert.attribute(".hidden-text", "hidden");
+    });
+
+    it("Attribute From Node", async() => {
+        await browser.open(configUrls.index);
+        const element = await browser.query(".hidden-text");
+        await browser.assert.attribute(element, "class", "hidden-text");
+        await browser.assert.attribute(element, "hidden", "");
+    });
+
+    it("Attribute Throws", async() => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.attribute(".hidden-text", "class", "hidden");
+        }, `Expected element ".hidden-text" to have attribute "class" with value "hidden". "hidden-text" found`);
+
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.attribute(".second-element", "hidden");
+        }, `Expected element ".second-element" to have attribute "hidden".`);
+    });
+
+    it("Attribute Throws With No Element Found", async() => {
+        await browser.open(configUrls.index);
+
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.attribute(".not-and-element", "class", "hidden");
+        }, `Expected element ".not-and-element" to have attribute "class" with value "hidden". No element found`);
+    });
+
+    it("Attribute Throws With Custom Message", async() => {
+        await browser.open(configUrls.index);
+
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.attribute(".hidden-text", "class", "hidden", "attribute error");
+        }, `attribute error`);
+    });
+
+});

--- a/tests/assertions/assert_exists.test.js
+++ b/tests/assertions/assert_exists.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const Wendigo = require('../../lib/wendigo');
+const utils = require('../utils');
+const configUrls = require('../config.json').urls;
+
+describe("Assert Exists", function() {
+    this.timeout(5000);
+    let browser;
+
+    before(async () => {
+        browser = await Wendigo.createBrowser();
+    });
+
+    after(async() => {
+        await browser.close();
+    });
+
+    it("Exists", async () => {
+        await browser.open(configUrls.index);
+        await browser.assert.exists("h1");
+        await browser.assert.exists(".container");
+    });
+
+    it("Exists Throws", async () => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.exists("h2");
+        }, `Expected element "h2" to exists`);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.exists(".not_container");
+        }, `Expected element ".not_container" to exists`);
+    });
+
+    it("Exists Throws With Custom Message", async () => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.exists("h2", "test failed");
+        }, `test failed`);
+    });
+
+    it("Exists From Node", async () => {
+        await browser.open(configUrls.index);
+        const node = await browser.query("h1");
+        await browser.assert.exists(node);
+        await browser.assert.exists(".container");
+    });
+
+    it("Not Exists", async () => {
+        await browser.open(configUrls.index);
+        await browser.assert.not.exists("h2");
+        await browser.assert.not.exists(".not-container");
+    });
+
+    it("Not Exists Throws", async () => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.exists("h1");
+        }, `Expected element "h1" to not exists`);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.exists(".container");
+        }, `Expected element ".container" to not exists`);
+    });
+
+    it("Not Exists Throws With Custom Message", async () => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAssertionAsync(async () => {
+            await browser.assert.not.exists("h1", "not exists failed");
+        }, `not exists failed`);
+    });
+
+});

--- a/tests/browser_assert.test.js
+++ b/tests/browser_assert.test.js
@@ -17,36 +17,6 @@ describe("Assertions", function() {
         await browser.close();
     });
 
-    it("Exists", async () => {
-        await browser.open(configUrls.index);
-        await browser.assert.exists("h1");
-        await browser.assert.exists(".container");
-    });
-
-    it("Exists Throws", async () => {
-        await browser.open(configUrls.index);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.exists("h2");
-        }, `Expected element "h2" to exists`);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.exists(".not_container");
-        }, `Expected element ".not_container" to exists`);
-    });
-
-    it("Exists Throws With Custom Message", async () => {
-        await browser.open(configUrls.index);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.exists("h2", "test failed");
-        }, `test failed`);
-    });
-
-    it("Exists From Node", async () => {
-        await browser.open(configUrls.index);
-        const node = await browser.query("h1");
-        await browser.assert.exists(node);
-        await browser.assert.exists(".container");
-    });
-
     it("Text", async () => {
         await browser.open(configUrls.index);
         await browser.assert.text("h1", "Main Title");

--- a/tests/browser_assert.test.js
+++ b/tests/browser_assert.test.js
@@ -25,17 +25,17 @@ describe("Assertions", function() {
 
     it("Exists Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.exists("h2");
         }, `Expected element "h2" to exists`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.exists(".not_container");
         }, `Expected element ".not_container" to exists`);
     });
 
     it("Exists Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.exists("h2", "test failed");
         }, `test failed`);
     });
@@ -66,27 +66,27 @@ describe("Assertions", function() {
 
     it("Text Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.text("h1", "My first paragraph");
         }, `Expected element "h1" to have text "My first paragraph", "Main Title" found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.text("h2", "My first paragraph");
         }, `Expected element "h2" to have text "My first paragraph", no text found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.text(".container p", "My second paragraph");
         }, `Expected element ".container p" to have text "My second paragraph", "My first paragraph" found`);
     });
 
     it("Multiple Text Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.text("p", "My paragraph");
         }, `Expected element "p" to have text "My paragraph", "My first paragraph My second paragraph" found`);
     });
 
     it("Text Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.text("h1", "My first paragraph", "text failed");
         }, `text failed`);
     });
@@ -102,7 +102,7 @@ describe("Assertions", function() {
     it("Is Visible Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.visible);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.visible(".hidden-text");
         }, `Expected element ".hidden-text" to be visible`);
     });
@@ -110,7 +110,7 @@ describe("Assertions", function() {
     it("Is Visible When Styled Hidden", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.visible);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.visible(".hidden-text2");
         }, `Expected element ".hidden-text2" to be visible`);
     });
@@ -118,7 +118,7 @@ describe("Assertions", function() {
     it("Is Visible When Element Not Exists", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.visible);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.visible(".not-exists");
         }, `Expected element ".not-exists" to be visible`);
     });
@@ -126,7 +126,7 @@ describe("Assertions", function() {
     it("Is Visible Throws With Custom Message", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.visible);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.visible(".hidden-text", "visible test failed");
         }, `visible test failed`);
     });
@@ -152,10 +152,10 @@ describe("Assertions", function() {
     it("Title Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.title);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.title("Index Test 2");
         }, `Expected page title to be "Index Test 2", "Index Test" found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.title("");
         }, `Expected page title to be "", "Index Test" found`);
     });
@@ -163,7 +163,7 @@ describe("Assertions", function() {
     it("Title Throws With Custom Message", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.title);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.title("Index Test 2", "title test failed");
         }, `title test failed`);
     });
@@ -177,7 +177,7 @@ describe("Assertions", function() {
     it("Class Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.class);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.class("div", "not-my-class");
         }, `Expected element "div" to contain class "not-my-class", "container extra-class" found`);
     });
@@ -185,7 +185,7 @@ describe("Assertions", function() {
     it("Class Throws Element Not Found", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.class);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.class("div.not-exists", "not-my-class");
         }, `Expected element "div.not-exists" to contain class "not-my-class", no classes found`);
     });
@@ -193,7 +193,7 @@ describe("Assertions", function() {
     it("Class Throws With Custom Message", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.class);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.class("div", "not-my-class", "class failed");
         }, `class failed`);
     });
@@ -213,7 +213,7 @@ describe("Assertions", function() {
     it("Url Throws", async() => {
         const invalidUrl = "http://localhost/not_the_url";
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.url(invalidUrl);
         }, `Expected url to be "${invalidUrl}", "${configUrls.index}" found`);
     });
@@ -221,7 +221,7 @@ describe("Assertions", function() {
     it("Url Throws With Custom Message", async() => {
         const invalidUrl = "http://localhost/not_the_url";
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.url(invalidUrl, "invalid url");
         }, `invalid url`);
     });
@@ -241,26 +241,26 @@ describe("Assertions", function() {
 
     it("Elements Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", 3);
         }, `Expected selector "p" to find exactly 3 elements, 2 found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", {atLeast: 3});
         }, `Expected selector "p" to find at least 3 elements, 2 found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", {atMost: 1});
         }, `Expected selector "p" to find up to 1 elements, 2 found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", {atMost: 4, atLeast: 3});
         }, `Expected selector "p" to find between 3 and 4 elements, 2 found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", {atMost: 1, atLeast: 0});
         }, `Expected selector "p" to find between 0 and 1 elements, 2 found`);
     });
 
     it("Elements Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.elements("p", 3, "elements failed");
         }, `elements failed`);
     });
@@ -272,17 +272,17 @@ describe("Assertions", function() {
 
     it("Element Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.element("p.not-exist");
         }, `Expected selector "p.not-exist" to find exactly 1 elements, 0 found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.element("p");
         }, `Expected selector "p" to find exactly 1 elements, 2 found`);
     });
 
     it("Element Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.element("p", "element failed");
         }, `element failed`);
     });
@@ -309,17 +309,17 @@ describe("Assertions", function() {
 
     it("Text Contains Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.textContains(".container p", "My second");
         }, `Expected element ".container p" to contain text "My second", "My first paragraph" found`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.textContains("p", "My paragraph");
         }, `Expected element "p" to contain text "My paragraph", "My first paragraph My second paragraph" found`);
     });
 
     it("Text Contains Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.textContains(".container p", "My second", "text contains fails");
         }, `text contains fails`);
     });

--- a/tests/browser_assert_not.test.js
+++ b/tests/browser_assert_not.test.js
@@ -17,29 +17,6 @@ describe("Not Assertions", function() {
         await browser.close();
     });
 
-    it("Not Exists", async () => {
-        await browser.open(configUrls.index);
-        await browser.assert.not.exists("h2");
-        await browser.assert.not.exists(".not-container");
-    });
-
-    it("Not Exists Throws", async () => {
-        await browser.open(configUrls.index);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.not.exists("h1");
-        }, `Expected element "h1" to not exists`);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.not.exists(".container");
-        }, `Expected element ".container" to not exists`);
-    });
-
-    it("Not Exists Throws With Custom Message", async () => {
-        await browser.open(configUrls.index);
-        await utils.assertThrowsAssertionAsync(async () => {
-            await browser.assert.not.exists("h1", "not exists failed");
-        }, `not exists failed`);
-    });
-
     it("Not Text", async () => {
         await browser.open(configUrls.index);
         await browser.assert.not.text("h1", "Not Main Title");

--- a/tests/browser_assert_not.test.js
+++ b/tests/browser_assert_not.test.js
@@ -25,17 +25,17 @@ describe("Not Assertions", function() {
 
     it("Not Exists Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.exists("h1");
         }, `Expected element "h1" to not exists`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.exists(".container");
         }, `Expected element ".container" to not exists`);
     });
 
     it("Not Exists Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.exists("h1", "not exists failed");
         }, `not exists failed`);
     });
@@ -57,17 +57,17 @@ describe("Not Assertions", function() {
 
     it("Not Multiple Texts Throws", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.text("p", "My first paragraph");
         }, `Expected element "p" not to have text "My first paragraph"`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.text("p", "My second paragraph");
         }, `Expected element "p" not to have text "My second paragraph"`);
     });
 
     it("Not Text Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.text("p", "My first paragraph", "not text failed");
         }, `not text failed`);
     });
@@ -88,17 +88,17 @@ describe("Not Assertions", function() {
     it("Not Visible Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.visible);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.visible("p");
         }, `Expected element "p" to not be visible`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.visible("h1");
         }, `Expected element "h1" to not be visible`);
     });
 
     it("Not Visible Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.visible("p", "not visible failed");
         }, `not visible failed`);
     });
@@ -117,7 +117,7 @@ describe("Not Assertions", function() {
     it("Not Title Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.title);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.title("Index Test");
         }, `Expected page title not to be "Index Test"`);
     });
@@ -125,7 +125,7 @@ describe("Not Assertions", function() {
     it("Not Title Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.title);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.title("Index Test", "not title failed");
         }, `not title failed`);
     });
@@ -139,7 +139,7 @@ describe("Not Assertions", function() {
     it("Not Url Throws", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.url);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.url(configUrls.index);
         }, `Expected url not to be "${configUrls.index}"`);
     });
@@ -147,7 +147,7 @@ describe("Not Assertions", function() {
     it("Not Url Throws With Custom Message", async() => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.url);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.url(configUrls.index, "not url failed");
         }, `not url failed`);
     });
@@ -166,17 +166,17 @@ describe("Not Assertions", function() {
     it("Not Text Contains Throws", async () => {
         await browser.open(configUrls.index);
         assert(browser.assert.not.textContains);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.textContains("p", "My second");
         }, `Expected element "p" not to contain text "My second"`);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.textContains("p", "My first");
         }, `Expected element "p" not to contain text "My first"`);
     });
 
     it("Not Text Contains Throws With Custom Message", async () => {
         await browser.open(configUrls.index);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.textContains(".container p", "My second", "text contains fails");
         }, `text contains fails`);
     });

--- a/tests/browser_base.test.js
+++ b/tests/browser_base.test.js
@@ -3,6 +3,7 @@
 const Wendigo = require('../lib/wendigo');
 const assert = require('assert');
 const configUrls = require('./config.json').urls;
+const utils = require('./utils');
 
 describe("Browser Base", function() {
     this.timeout(5000);
@@ -86,5 +87,43 @@ describe("Browser Base", function() {
         assert.strictEqual(classes.length, 2);
         assert.strictEqual(classes[0], "container");
         assert.strictEqual(classes[1], "extra-class");
+    });
+
+    it("Attribute", async() => {
+        await browser.open(configUrls.index);
+        const classAttribute = await browser.attribute(".container", "class");
+        assert.strictEqual(classAttribute, "container extra-class");
+    });
+
+    it("Attribute With Multiple Elements", async() => {
+        await browser.open(configUrls.index);
+        const classAttribute = await browser.attribute("b", "class");
+        assert.strictEqual(classAttribute, "hidden-text2");
+    });
+
+    it("Empty Attribute", async() => {
+        await browser.open(configUrls.index);
+        const hiddenAttribute = await browser.attribute(".hidden-text", "hidden");
+        assert.strictEqual(hiddenAttribute, "");
+    });
+
+    it("Non Existing Attribute", async() => {
+        await browser.open(configUrls.index);
+        const hiddenAttribute = await browser.attribute(".container", "hidden");
+        assert.strictEqual(hiddenAttribute, null);
+    });
+
+    it("Attribute With Non Existing Element", async() => {
+        await browser.open(configUrls.index);
+        await utils.assertThrowsAsync(async () => {
+            await browser.attribute(".not-element", "class");
+        }, `Error: Element ".not-element" not found when trying to get attribute "class".`);
+    });
+
+    it("Attribute From Node", async() => {
+        await browser.open(configUrls.index);
+        const node = await browser.query('.container');
+        const classAttribute = await browser.attribute(node, "class");
+        assert.strictEqual(classAttribute, "container extra-class");
     });
 });

--- a/tests/browser_forms.test.js
+++ b/tests/browser_forms.test.js
@@ -66,22 +66,22 @@ describe("Browser Forms", function() {
 
     it("Assert Value Throws", async() => {
         await browser.open(configUrls.forms);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.value("input.input1", "False Text");
         }, `Expected element "input.input1" to have value "False Text", "" found`);
 
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.value("input.input2", "False Text");
         }, `Expected element "input.input2" to have value "False Text", "default value" found`);
 
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.value("input.not-exists", "False Text");
         }, `Expected element "input.not-exists" to have value "False Text", no value found`);
     });
 
     it("Assert Value Throws Custom Message", async() => {
         await browser.open(configUrls.forms);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.value("input.input1", "False Text", "value failed");
         }, `value failed`);
     });
@@ -101,22 +101,22 @@ describe("Browser Forms", function() {
 
     it("Assert Not Value Throws", async() => {
         await browser.open(configUrls.forms);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.value("input.input1", "");
         }, `Expected element "input.input1" not to have value ""`);
 
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.value("input.input2", "default value");
         }, `Expected element "input.input2" not to have value "default value"`);
 
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.value("h1", null);
         }, `Expected element "h1" not to have value "null"`);
     });
 
     it("Assert Not Value Throws", async() => {
         await browser.open(configUrls.forms);
-        await utils.assertThrowsAsync(async () => {
+        await utils.assertThrowsAssertionAsync(async () => {
             await browser.assert.not.value("input.input1", "", "not value failed");
         }, `not value failed`);
     });

--- a/tests/browser_interactions.test.js
+++ b/tests/browser_interactions.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const assert = require('assert');
 const Wendigo = require('../lib/wendigo');
 const utils = require('./utils');
 const configUrls = require('./config.json').urls;
@@ -19,14 +20,16 @@ describe("Browser Interactions", function() {
     it("Click", async() => {
         await browser.open(configUrls.click);
         await browser.assert.text("#switch", "On");
-        await browser.click(".btn");
+        const clickedElements = await browser.click(".btn");
         await browser.assert.text("#switch", "Off");
+        assert.strictEqual(clickedElements, 1);
     });
 
     it("Click Multiple Elements", async() => {
         await browser.open(configUrls.click);
         await browser.assert.text("#switch", "On");
-        await browser.click("button");
+        const clickedElements = await browser.click("button");
+        assert.strictEqual(clickedElements, 2);
         await browser.assert.text("#switch", "Off");
         await browser.waitFor("#switch.on", 600);
     });
@@ -34,7 +37,8 @@ describe("Browser Interactions", function() {
     it("Click With Index", async() => {
         await browser.open(configUrls.click);
         await browser.assert.text("#switch", "On");
-        await browser.click("button", 1);
+        const clickedElements = await browser.click("button", 1);
+        assert.strictEqual(clickedElements, 1);
         await browser.assert.text("#switch", "On");
         await browser.waitFor("#switch.off", 600);
     });
@@ -42,7 +46,8 @@ describe("Browser Interactions", function() {
     it("Click From Node", async() => {
         await browser.open(configUrls.click);
         const node = await browser.query(".btn");
-        await browser.click(node);
+        const clickedElements = await browser.click(node);
+        assert.strictEqual(clickedElements, 1);
         await browser.assert.text("#switch", "Off");
     });
 
@@ -51,7 +56,7 @@ describe("Browser Interactions", function() {
         await browser.assert.text("#switch", "On");
         await utils.assertThrowsAsync(async () => {
             await browser.click("button", 10);
-        }); // TODO: check text
+        }, `Error: browser.click, invalid index "10" for selector "button", 2 elements found.`);
         await browser.assert.text("#switch", "On");
     });
 
@@ -88,7 +93,7 @@ describe("Browser Interactions", function() {
         await browser.click(".btn2");
         await utils.assertThrowsAsync(async () => {
             await browser.waitFor("#switch.off", 10);
-        });
+        }, `Error: Waiting for element "#switch.off" failed, timeout of 10ms exceeded`);
         await browser.assert.not.exists("#switch.off");
         await browser.assert.exists("#switch.on");
         await browser.assert.text("#switch", "On");
@@ -96,7 +101,8 @@ describe("Browser Interactions", function() {
 
     it("Click Text", async() => {
         await browser.open(configUrls.click);
-        await browser.clickText("click me");
+        const clickedElements = await browser.clickText("click me");
+        assert.strictEqual(clickedElements, 1);
         await browser.assert.text("#switch", "Off");
         await browser.clickText("click me");
         await browser.assert.text("#switch", "On");
@@ -104,7 +110,9 @@ describe("Browser Interactions", function() {
 
     it("Click Invalid Text", async() => {
         await browser.open(configUrls.click);
-        await browser.clickText("not click me");
+        await utils.assertThrowsAsync(async () => {
+            await browser.clickText("not click me");
+        }, `Error: No element with text "not click me" found when trying to click.`);
         await browser.assert.text("#switch", "On");
     });
 
@@ -115,4 +123,6 @@ describe("Browser Interactions", function() {
         await browser.assert.text("#switch", "Off");
         await browser.waitFor("#switch.on", 600);
     });
+
+    it("Click Invalid Element");
 });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -2,6 +2,9 @@
 const assert = require('assert');
 
 module.exports = {
+    async assertThrowsAssertionAsync(fn, expected) {
+        return this.assertThrowsAsync(fn, `AssertionError [ERR_ASSERTION]: ${expected}`);
+    },
     async assertThrowsAsync(fn, expected) {
         let f = () => {};
         try {
@@ -13,7 +16,7 @@ module.exports = {
         } finally {
             assert.throws(f, (err) => {
                 if(expected) {
-                    return err.toString() === `AssertionError [ERR_ASSERTION]: ${expected}`;
+                    return err.toString() === expected;
                 } else return true;
             });
         }


### PR DESCRIPTION
  * Attribute and not attribute assertions
  * browser.attribute method
  * browser.click and browser.clickText throws if no element is found, return the number of elements
  * Puppeteer settings are now passed down in createBrowser, including slowMo
  * Minor improvements in assertion messages