### PR TITLE
remove browser on close #233

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ class Wendigo {
 
     _processSettings(settings) {
         settings = Object.assign({}, defaultSettings, settings);
-        settings.__onClose = this._removeBrowser;
+        settings.__onClose = this._removeBrowser.bind(this);
         if (process.env.NO_SANDBOX || settings.noSandbox) {
             settings.args = settings.args.concat(['--no-sandbox', '--disable-setuid-sandbox']); // Required to run on some systems
         }

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class Wendigo {
         this.clearPlugins();
         return Promise.all(this.browsers.map((b) => {
             return b.close();
-        }));
+        })).then(() => this.browsers=[]); // reset browsers before returning promise.
     }
 
     /* eslint-disable complexity */
@@ -109,8 +109,17 @@ class Wendigo {
         });
     }
 
+    _removeBrowser(browser) {
+        idx = this.browsers.indexOf(browser);
+        if (idx === -1) {
+            throw new Errors.FatalError("browser not found on closing.")
+        }
+        this.browsers.splice(idx, 1);
+    }
+
     _processSettings(settings) {
         settings = Object.assign({}, defaultSettings, settings);
+        settings.__onClose = this._removeBrowser;
         if (process.env.NO_SANDBOX || settings.noSandbox) {
             settings.args = settings.args.concat(['--no-sandbox', '--disable-setuid-sandbox']); // Required to run on some systems
         }

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ class Wendigo {
     }
 
     _removeBrowser(browser) {
-        idx = this.browsers.indexOf(browser);
+        let idx = this.browsers.indexOf(browser);
         if (idx === -1) {
             throw new Errors.FatalError("browser not found on closing.")
         }

--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ class Wendigo {
         this.clearPlugins();
         return Promise.all(this.browsers.map((b) => {
             return b.close();
-        })).then(() => this.browsers=[]); // reset browsers before returning promise.
+        })).then(() => {
+            this.browsers = [];
+        }); // reset browsers before returning promise.
     }
 
     /* eslint-disable complexity */
@@ -110,9 +112,9 @@ class Wendigo {
     }
 
     _removeBrowser(browser) {
-        let idx = this.browsers.indexOf(browser);
+        const idx = this.browsers.indexOf(browser);
         if (idx === -1) {
-            throw new Errors.FatalError("browser not found on closing.")
+            throw new Errors.FatalError("browser not found on closing.");
         }
         this.browsers.splice(idx, 1);
     }

--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -111,6 +111,7 @@ module.exports = class BrowserCore {
     }
 
     _beforeClose() {
+        this._settings.__onClose(this);
         return this._callComponentsMethod("_beforeClose");
     }
 


### PR DESCRIPTION
resolves #233 

my approach was to preserve existing function signatures and include a member setting.__onClose. I didn't change the name of .browsers, but I would be happy to if you think it's necessary.

Let me know if you have any feedback or suggestions!