### PR TITLE
Add workaround when not allowed to inject wendigo scripts

### DIFF
--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fs = require('fs');
 const path = require('path');
 const {
     FatalError

--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -147,6 +147,9 @@ module.exports = class BrowserCore {
         const promises = injectionScripts.map((s) => {
             return this.page.addScriptTag({ // Not using wrapper as this is before loaded is true
                 path: path.join(injectionScriptsPath, s)
+            }).catch(() => {
+                const contents = fs.readFileSync(path.join(injectionScriptsPath, s), 'utf8');
+                return this.page.evaluate(contents);
             });
         });
         return Promise.all(promises);


### PR DESCRIPTION
Woraround for this issue https://github.com/GoogleChrome/puppeteer/issues/1221