### PR TITLE
1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Support for an object with assert and not functions for a plugin
 * RegExp support for waitForUrl
+* Mock.trigger accepts an optional response
 * Cookies is now fully implemented as a plugin
 
 1.12.1 / 2018-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ===================
 
 * Minor improvements to dockerfile
+* Fix on using log: true when console.warn is used in the page
 
 1.12.0 / 2018-03-25
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-1.12.1 / ####-##-##
+1.12.1 / 2018-03-25
 ===================
 
 * Minor improvements to dockerfile
-* Fix on using log: true when console.warn is used in the page
+* Fix of console.warn logs when set the option log: true
 
 1.12.0 / 2018-03-25
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.13.0 / ####-##-##
+1.13.0 / 2018-03-29
 ===================
 
 * Support for an object with assert and not functions for a plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 * Support for an object with assert and not functions for a plugin
 * RegExp support for waitForUrl
 * Mock.trigger accepts an optional response
+* Browser.evaluate now supports returning DOMElements
 * Puppeteer updated to 1.14.0
 * Cookies is now fully implemented as a plugin
+* ElementFromPoint not returns null if no element is found
 
 1.12.1 / 2018-03-25
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ===================
 
 * Support for an object with assert and not functions for a plugin
+* RegExp support for waitForUrl
 * Cookies is now fully implemented as a plugin
 
 1.12.1 / 2018-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.13.0 / ####-##-##
+===================
+
+* Support for an object with assert and not functions for a plugin
+* Cookies is now fully implemented as a plugin
+
 1.12.1 / 2018-03-25
 ===================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Support for an object with assert and not functions for a plugin
 * RegExp support for waitForUrl
 * Mock.trigger accepts an optional response
+* Puppeteer updated to 1.14.0
 * Cookies is now fully implemented as a plugin
 
 1.12.1 / 2018-03-25

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ await browser.waitUntilNotVisible(".toast");
 > Css and XPath selectors supported only.
 
 **waitForUrl(url, timeout=500)**  
-Waits for the page to have the given url.
+Waits for the page to have the given url. The url can be a string or a RegExp.
 
 ```js
 await browser.click("a");

--- a/README.md
+++ b/README.md
@@ -209,7 +209,18 @@ const elementText = await browser.evaluate((s) => {
 }, selector); // My Title
 ```
 
-> This is a wrapper around browser.page.evaluate
+This method, unlike `browser.page.evaluate` will automatically parse DOMElements arguments and DOMElements returns:
+
+```js
+const selector = "h1";
+const element = await browser.evaluate((s) => {
+    return document.querySelector(s);
+}, selector); // DOMElement
+
+const elementText = await browser.evaluate((e)=>{
+    return e.textContent;
+}, element); // My Title
+```
 
 **query(selector, childSelector?)**  
 Queries the given css selector and returns a DOM element. If multiple elements are matched, only the first will be returned. Returns null if no element found.
@@ -243,7 +254,7 @@ elements[0].textContent; // "My first paragraph"
 > The DomElement class returned by all query methods provides an interface to Puppeteer's ElementHandle class, it can be accesed with the property `element`
 
 **elementFromPoint(x, y)**  
-Given the coordinates (in pixels) as two numbers, returns the topmost DomElement in that position or `undefined` if no element is present.
+Given the coordinates (in pixels) as two numbers, returns the topmost DomElement in that position or `null` if no element is present.
 
 ```js
 const element = await browser.elementFromPoint(500, 150);

--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,8 @@ callApi();
 mock.trigger();
 ```
 
+Trigger supports an optional response that will be used instead of the mock default response. It uses the same syntax (body, status, ...).
+
 **removeMock(url, options?)**  
 Removes the mock with the given url. If the original mock has a method or queryString, these must be provided in options.
 

--- a/README.md
+++ b/README.md
@@ -1614,7 +1614,7 @@ browser.assert.koalafied.thereAreKoalas();
 * **plugin**: Class to be used as plugin accessed under `browser.name`, this class will receive `browser` as constructor parameter and 2 methods can be implemented as hooks:
   * **_beforeOpen**: Called when `browser.open` is called, before opening the page.
   * **_beforeClose**: Called when `browser.close` is called, before closing the page.
-* **assertion**: Class to be used as plugin's assertions, it can be accessed on `browser.assertion.name` the constructor will received both the browser and the core plugin as parameters
+* **assertion**: Class to be used as plugin's assertions, it can be accessed on `browser.assertion.name` the constructor will receive both the browser and the core plugin as parameters
 
 registerPlugin also accepts a single object containing the data in the following structure:
 
@@ -1635,6 +1635,24 @@ function myPluginAssertionFunc(browser, myPlugin, count){
 
 Wendigo.registerPlugin("koalafied", MyPlugin, MyPluginAssertions);
 browser.assert.koalafied(); // note the assertion is called directly
+```
+
+An object with 2 functions "assert" and "not" can also be passed as an assertion to registerModule. In this case, both will be attached to the main modules `assert` and `assert.not`:
+
+```js
+const myAssertion = {
+    assert(browser, myPlugin, count){
+        // koala count assertion
+    },
+    not(browser, myPlugin, count){
+        // not assertion check
+    }
+
+}
+
+Wendigo.registerPlugin("koalafied", MyPlugin, MyPluginAssertions);
+browser.assert.koalafied();
+browser.assert.not.koalafied();
 ```
 
 ### Publishing a plugin

--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -94,10 +94,14 @@ module.exports = class BrowserCore {
         });
     }
 
-    evaluate(cb, ...args) {
+    async evaluate(cb, ...args) {
         this._failIfNotLoaded("evaluate");
         args = this._setupEvaluateArguments(args);
-        return this.page.evaluate(cb, ...args);
+        const rawResult = await this.page.evaluateHandle(cb, ...args);
+        const resultAsElement = rawResult.asElement();
+        if (resultAsElement) {
+            return DomElement.processQueryResult(rawResult);
+        } else return rawResult.jsonValue();
     }
 
     setViewport(config = {}) {

--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -96,10 +96,7 @@ module.exports = class BrowserCore {
 
     evaluate(cb, ...args) {
         this._failIfNotLoaded("evaluate");
-        args = args.map((e) => {
-            if (e instanceof DomElement) return e.element;
-            else return e;
-        });
+        args = this._setupEvaluateArguments(args);
         return this.page.evaluate(cb, ...args);
     }
 
@@ -134,6 +131,13 @@ module.exports = class BrowserCore {
             path: scriptPath
         }).catch((err) => {
             return Promise.reject(new InjectScriptError("open", err));
+        });
+    }
+
+    _setupEvaluateArguments(args) {
+        return args.map((e) => {
+            if (e instanceof DomElement) return e.element;
+            else return e;
         });
     }
 

--- a/lib/browser_core.js
+++ b/lib/browser_core.js
@@ -25,8 +25,10 @@ const defaultOpenOptions = {
 
 function pageLog(log) {
     utils.stringifyLogText(log).then(text => {
-        log._text = text;
-        console[log._type](log._text); // eslint-disable-line
+        let logType = log._type;
+        if (logType === 'warning') logType = 'warn';
+        if (!console[logType]) logType = 'log'; // eslint-disable-line no-console
+        console[logType](text); // eslint-disable-line no-console
     });
 }
 

--- a/lib/browser_factory.js
+++ b/lib/browser_factory.js
@@ -5,6 +5,7 @@ const mix = require('mixwith').mix;
 const compose = require('compositer');
 const BrowserCore = require('./browser_core');
 const BrowserAssertion = require('./modules/assertions/browser_assertions');
+const BrowserNotAssertions = require('./modules/assertions/browser_not_assertions');
 
 const mixins = [
     require("./mixins/browser_actions"),
@@ -35,14 +36,21 @@ module.exports = class BrowserFactory {
     static _setupBrowserPlugins(BaseClass, plugins) {
         const components = {};
         const assertComponents = {};
+        const notAssertFunctions = {};
         for (const p of plugins) {
             if (p.plugin) {
                 components[p.name] = p.plugin;
             }
             if (p.assertions) {
                 assertComponents[p.name] = this._setupAssertionModule(p.assertions, p.name);
+                if (typeof p.assertions.not === 'function') {
+                    notAssertFunctions[p.name] = this._setupAssertionFunction(p.assertions.not, p.name);
+                }
             }
         }
+
+        const NotAssertModule = compose(BrowserNotAssertions, notAssertFunctions);
+        assertComponents.not = NotAssertModule;
         const AssertModule = compose(BrowserAssertion, assertComponents);
         const finalComponents = Object.assign({}, components, {"assert": AssertModule});
         return compose(BaseClass, finalComponents);
@@ -56,8 +64,10 @@ module.exports = class BrowserFactory {
     static _setupAssertionModule(AssertionPlugin, name) {
         if (isClass(AssertionPlugin)) {
             return this._setupAssertionClass(AssertionPlugin, name);
-        } else {
+        } else if (typeof AssertionPlugin === 'function') {
             return this._setupAssertionFunction(AssertionPlugin, name);
+        } else if (typeof AssertionPlugin.assert === 'function') {
+            return this._setupAssertionFunction(AssertionPlugin.assert, name);
         }
     }
 

--- a/lib/mixins/browser_queries.js
+++ b/lib/mixins/browser_queries.js
@@ -99,13 +99,10 @@ module.exports = function BrowserQueriesMixin(s) {
         elementFromPoint(x, y) {
             this._failIfNotLoaded("elementFromPoint");
             if (typeof x !== 'number' || typeof y !== 'number') return Promise.reject(new FatalError("elementFromPoint", `Invalid coordinates [${x},${y}].`));
-            return this.page.evaluateHandle((evalX, evalY) => {
+            return this.evaluate((evalX, evalY) => {
                 const element = document.elementFromPoint(evalX, evalY);
-                return element || undefined;
-            }, x, y).then((elementHandle) => {
-                if (elementHandle._remoteObject.type === 'undefined') return undefined;
-                else return DomElement.processQueryResult(elementHandle);
-            });
+                return element;
+            }, x, y);
         }
 
         _subQueryXpath(fnName, parent, selector) {

--- a/lib/mixins/browser_wait.js
+++ b/lib/mixins/browser_wait.js
@@ -40,11 +40,24 @@ module.exports = function BrowserWaitMixin(s) {
 
         waitForUrl(url, timeout = 500) {
             this._failIfNotLoaded("waitForUrl");
+            if (!url) return Promise.reject(new WendigoError("waitForUrl", `Invalid parameter url.`));
+            let parsedUrl = url;
+            if (url instanceof RegExp) {
+                parsedUrl = {
+                    source: url.source,
+                    flags: url.flags
+                };
+            }
             return this.waitFor((expectedUrl) => {
-                let currentUrl = window.location.href;
-                if (currentUrl === "about:blank") currentUrl = null;
-                return currentUrl === expectedUrl;
-            }, timeout, url).catch(() => {
+                const currentUrl = window.location.href;
+                if (currentUrl === "about:blank") return false;
+                if (typeof expectedUrl === 'string') {
+                    return currentUrl === expectedUrl;
+                } else if (expectedUrl.source) {
+                    const regex = new RegExp(expectedUrl.source, expectedUrl.flags);
+                    return regex.test(currentUrl);
+                }
+            }, timeout, parsedUrl).catch(() => {
                 return Promise.reject(new TimeoutError("waitForUrl", `Waiting for url "${url}"`, timeout));
             });
         }

--- a/lib/models/request_mock.js
+++ b/lib/models/request_mock.js
@@ -11,12 +11,7 @@ const utils = require('../utils/utils');
 module.exports = class RequestMock {
     constructor(url, options) {
         this._setURL(url);
-        this._response = {
-            status: options.status,
-            headers: options.headers,
-            contentType: options.contentType,
-            body: this._processBody(options.body)
-        };
+        this._response = this._processResponse(options);
         this.delay = options.delay || 0;
         this.method = options.method;
         if (options.queryString || typeof options.queryString === "string") this.queryString = utils.parseQueryString(options.queryString);
@@ -53,9 +48,9 @@ module.exports = class RequestMock {
         return this._auto;
     }
 
-    trigger() {
+    trigger(response) {
         if (this.auto) throw new FatalError("trigger", `Cannot trigger auto request mock.`);
-        this._events.emit("respond");
+        this._events.emit("respond", response);
     }
 
     async waitUntilCalled(timeout = 500) {
@@ -86,13 +81,17 @@ module.exports = class RequestMock {
                 return this._respondRequest(request);
             });
         } else {
-            this._onTrigger(() => {
-                return this._respondRequest(request);
+            this._onTrigger((response) => {
+                return this._respondRequest(request, response);
             });
         }
     }
 
-    async _respondRequest(request) {
+    async _respondRequest(request, optionalResponse) {
+        let response = this.response;
+        if (optionalResponse) {
+            response = this._processResponse(optionalResponse);
+        }
         if (this._redirectTo) {
             const url = new URL(request.url());
             let qs = url.searchParams.toString();
@@ -100,7 +99,7 @@ module.exports = class RequestMock {
             await request.continue({
                 url: `${this._redirectTo.origin}${this._redirectTo.pathname}${qs || ""}`
             });
-        } else await request.respond(this.response);
+        } else await request.respond(response);
         this._events.emit("on-request");
     }
 
@@ -130,6 +129,15 @@ module.exports = class RequestMock {
                 return Promise.reject(new AssertionError("assert.postBody", msg));
             }
         });
+    }
+
+    _processResponse(options) {
+        return {
+            status: options.status,
+            headers: options.headers,
+            contentType: options.contentType,
+            body: this._processBody(options.body)
+        };
     }
 
     _processBody(rawBody) {

--- a/lib/modules/assertions/browser_assertions.js
+++ b/lib/modules/assertions/browser_assertions.js
@@ -6,14 +6,13 @@ const utils = require('../../utils/utils');
 const elementsAssertionUtils = require('../../utils/assert_elements');
 const assertUtils = require('../../utils/assert_utils');
 const RequestAssertionsFilter = require('../requests/request_assertions_filter');
-const BrowserNotAssertions = require('./browser_not_assertions');
 const deprecationWarning = require('../../utils/deprecation_warning');
 const {QueryError, FatalError, WendigoError} = require('../../errors');
 
 module.exports = class BrowserAssertions {
     constructor(browser) {
         this._browser = browser;
-        this.not = new BrowserNotAssertions(browser, this);
+        // Not assertions are dinamically added
     }
 
     get request() {

--- a/lib/modules/assertions/browser_not_assertions.js
+++ b/lib/modules/assertions/browser_not_assertions.js
@@ -6,9 +6,9 @@ const deprecationWarning = require('../../utils/deprecation_warning');
 const {WendigoError, QueryError} = require('../../errors');
 
 module.exports = class BrowserNotAssertions {
-    constructor(browser, browserAssertions) {
-        this._browser = browser;
-        this._assertions = browserAssertions;
+    constructor(assertions) {
+        this._assertions = assertions;
+        this._browser = assertions._browser;
     }
 
     exists(selector, msg) {
@@ -148,17 +148,6 @@ module.exports = class BrowserNotAssertions {
         // DEPRECATED
         deprecationWarning("browser.assert.not.cookie", "browser.asssert.not.cookies");
         return this.cookies(...args);
-    }
-
-    cookies(name, expected, msg) { // TODO: somehow stick this in module, cannot do due to module being a function
-        if (!msg) {
-            msg = expected === undefined ?
-                `Expected cookie "${name}" to not exist.` :
-                `Expected cookie "${name}" to not have value "${expected}".`;
-        }
-        return assertUtils.invertify(() => {
-            return this._assertions.cookies(name, expected, "x");
-        }, "assert.not.cookies", msg);
     }
 
     async checked(selector, msg) {

--- a/lib/modules/cookies/cookies_assertion.js
+++ b/lib/modules/cookies/cookies_assertion.js
@@ -2,21 +2,33 @@
 
 const assertUtils = require('../../utils/assert_utils');
 /* eslint-disable max-params */
-module.exports = function cookies(browser, cookiesModule, name, expected, msg) {
-    return cookiesModule.get(name).then((value) => {
-        if (expected === undefined) {
-            if (value === undefined) {
-                if (!msg) {
-                    msg = `Expected cookie "${name}" to exist.`;
+module.exports = {
+    assert(browser, cookiesModule, name, expected, msg) {
+        return cookiesModule.get(name).then((value) => {
+            if (expected === undefined) {
+                if (value === undefined) {
+                    if (!msg) {
+                        msg = `Expected cookie "${name}" to exist.`;
+                    }
+                    return assertUtils.rejectAssertion("assert.cookies", msg);
                 }
-                return assertUtils.rejectAssertion("assert.cookies", msg);
+            } else if (value !== expected) {
+                if (!msg) {
+                    msg = `Expected cookie "${name}" to have value "${expected}", "${value}" found.`;
+                }
+                return assertUtils.rejectAssertion("assert.cookies", msg, value, expected);
             }
-        } else if (value !== expected) {
-            if (!msg) {
-                msg = `Expected cookie "${name}" to have value "${expected}", "${value}" found.`;
-            }
-            return assertUtils.rejectAssertion("assert.cookies", msg, value, expected);
+        });
+    },
+    not(browser, cookiesModule, name, expected, msg) {
+        if (!msg) {
+            msg = expected === undefined ?
+                `Expected cookie "${name}" to not exist.` :
+                `Expected cookie "${name}" to not have value "${expected}".`;
         }
-    });
+        return assertUtils.invertify(() => {
+            return browser.assert.cookies(name, expected, "x");
+        }, "assert.not.cookies", msg);
+    }
 };
 /* eslint-enable max-params */

--- a/package-lock.json
+++ b/package-lock.json
@@ -2377,9 +2377,9 @@
       "dev": true
     },
     "parent-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
@@ -2491,9 +2491,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.13.0.tgz",
-      "integrity": "sha512-LUXgvhjfB/P6IOUDAKxOcbCz9ISwBLL9UpKghYrcBDwrOGx1m60y0iN2M64mdAUbT4+7oZM5DTxOW7equa2fxQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.14.0.tgz",
+      "integrity": "sha512-SayS2wUX/8LF8Yo2Rkpc5nkAu4Jg3qu+OLTDSOZtisVQMB2Z5vjlY2TdPi/5CgZKiZroYIiyUN3sRX63El9iaw==",
       "requires": {
         "debug": "^4.1.0",
         "extract-zip": "^1.6.6",
@@ -2705,9 +2705,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true
     },
     "send": {
@@ -3420,9 +3420,9 @@
       }
     },
     "ws": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
-      "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       "dev": true
     },
     "compositer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/compositer/-/compositer-1.3.2.tgz",
-      "integrity": "sha512-G3u067KmtTfpUVSnurOcKVn2eUdeRWl0kXgNVeUXwf1UTn2UkIlUQi7DkKFIDQarGJ9LCzFvk6hRr717Wdb5fQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/compositer/-/compositer-1.3.3.tgz",
+      "integrity": "sha512-LN0l3Y9DUDnjK2c0bf2LTrJmD/TrfBNu5uQ3XKMXML4R7ermDP4vxOGlDItml4eOLcUe4VoVNL+LQUFs5yZhqQ==",
       "requires": {
         "is-class": "0.0.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wendigo",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/angrykoala/wendigo#readme",
   "dependencies": {
-    "compositer": "^1.3.2",
+    "compositer": "^1.3.3",
     "is-class": "0.0.6",
     "mixwith": "^0.1.1",
     "puppeteer": "~1.13.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compositer": "^1.3.3",
     "is-class": "0.0.6",
     "mixwith": "^0.1.1",
-    "puppeteer": "~1.13.0"
+    "puppeteer": "~1.14.0"
   },
   "devDependencies": {
     "eslint": "^5.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wendigo",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "A proper monster for front-end automated testing",
   "engines": {
     "node": ">=8.0.0"

--- a/tests/assertions/assert_cookie.test.js
+++ b/tests/assertions/assert_cookie.test.js
@@ -4,7 +4,7 @@ const Wendigo = require('../..');
 const configUrls = require('../config.json').urls;
 const utils = require('../test_utils');
 
-describe("Assert Cookie", function() {
+describe("Assert Cookies", function() {
     this.timeout(5000);
     let browser;
 

--- a/tests/browser/drag.test.js
+++ b/tests/browser/drag.test.js
@@ -3,6 +3,7 @@
 const Wendigo = require('../..');
 const configUrls = require('../config.json').urls;
 
+// Tests #227
 describe.skip("Drag And Drop", function() {
     this.timeout(5000);
     let browser;

--- a/tests/browser/element_from_point.test.js
+++ b/tests/browser/element_from_point.test.js
@@ -33,7 +33,7 @@ describe("Element From Point", function() {
     it('No Element Found', async() => {
         await browser.open(configUrls.difficultClick);
         const element = await browser.elementFromPoint(4000, 4000);
-        assert.strictEqual(element, undefined);
+        assert.strictEqual(element, null);
     });
 
     it('Element From Point Throws', async() => {

--- a/tests/browser/evaluate.test.js
+++ b/tests/browser/evaluate.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Wendigo = require('../..');
+const DomElement = require('../../lib/models/dom_element');
 const assert = require('assert');
 const configUrls = require('../config.json').urls;
 
@@ -47,5 +48,59 @@ describe("Evaluate", function() {
             r.test("bba");
         }, regex);
         assert.strictEqual(match2, false);
+    });
+
+    it.skip("Evaluate Returning RegExp Element", async() => {
+        const result = await browser.evaluate(() => {
+            return /aba/g;
+        });
+        assert.ok(result instanceof RegExp);
+        assert.strictEqual(result.source, "aba");
+        assert.strictEqual(result.flags, "g");
+    });
+
+    it("Evaluate Returns String", async() => {
+        const result = await browser.evaluate(() => {
+            return "Test";
+        });
+        assert.strictEqual(result, "Test");
+    });
+
+    it("Evaluate Returns Number", async() => {
+        const result = await browser.evaluate(() => {
+            return 5;
+        });
+        assert.strictEqual(result, 5);
+    });
+
+    it("Evaluate Returns Object", async() => {
+        const result = await browser.evaluate(() => {
+            return {
+                name: "arthur",
+                surname: "dent"
+            };
+        });
+        assert.strictEqual(result.name, "arthur");
+        assert.strictEqual(result.surname, "dent");
+    });
+
+    it("Evaluate Returns Array", async() => {
+        const result = await browser.evaluate(() => {
+            return [1, "b", {
+                name: "arthur"
+            }];
+        });
+        assert.strictEqual(result.length, 3);
+        assert.strictEqual(result[0], 1);
+        assert.strictEqual(result[1], "b");
+        assert.strictEqual(result[2].name, "arthur");
+    });
+
+    // Tests #286
+    it.skip("Evaluate Returning DOM Element", async() => {
+        const result = await browser.evaluate(() => {
+            return document.querySelector("h1");
+        });
+        assert.ok(result instanceof DomElement);
     });
 });

--- a/tests/browser/evaluate.test.js
+++ b/tests/browser/evaluate.test.js
@@ -97,10 +97,11 @@ describe("Evaluate", function() {
     });
 
     // Tests #286
-    it.skip("Evaluate Returning DOM Element", async() => {
+    it("Evaluate Returning DOM Element", async() => {
         const result = await browser.evaluate(() => {
             return document.querySelector("h1");
         });
         assert.ok(result instanceof DomElement);
+        await browser.assert.text(result, "Main Title");
     });
 });

--- a/tests/browser/evaluate.test.js
+++ b/tests/browser/evaluate.test.js
@@ -36,7 +36,8 @@ describe("Evaluate", function() {
         assert.strictEqual(elementText, "Main Title");
     });
 
-    it.skip("Evaluate With Regexp Argument", async() => { // Not yet supported
+    // Tests #392
+    it.skip("Evaluate With Regexp Argument", async() => {
         const regex = /a.a/;
         const match = await browser.evaluate((r) => {
             r.test("aba");

--- a/tests/browser/evaluate.test.js
+++ b/tests/browser/evaluate.test.js
@@ -9,7 +9,7 @@ describe("Evaluate", function() {
 
     let browser;
     before(async() => {
-        browser = await Wendigo.createBrowser();
+        browser = await Wendigo.createBrowser({log: true});
     });
 
     beforeEach(async() => {
@@ -26,5 +26,25 @@ describe("Evaluate", function() {
             return document.querySelector(s).textContent;
         }, selector);
         assert.strictEqual(elementText, "Main Title");
+    });
+
+    it("Evaluate With DOMElement Argument", async() => {
+        const element = await browser.query("h1");
+        const elementText = await browser.evaluate((elem) => {
+            return elem.textContent;
+        }, element);
+        assert.strictEqual(elementText, "Main Title");
+    });
+
+    it.skip("Evaluate With Regexp Argument", async() => { // Not yet supported
+        const regex = /a.a/;
+        const match = await browser.evaluate((r) => {
+            r.test("aba");
+        }, regex);
+        assert.strictEqual(match, true);
+        const match2 = await browser.evaluate((r) => {
+            r.test("bba");
+        }, regex);
+        assert.strictEqual(match2, false);
     });
 });

--- a/tests/browser/mock_date.test.js
+++ b/tests/browser/mock_date.test.js
@@ -74,7 +74,8 @@ describe("Date Mock", function() {
         assert.strictEqual(expectedDate, 1201820400000);
     });
 
-    it.skip("Using Date As Function", async() => { // NOT SUPPORTED
+    // Tests #331
+    it.skip("Using Date As Function", async() => {
         await browser.mockDate(new Date(2010, 11, 10));
         await browser.click(".btn");
         const currentDates = await browser.evaluate(() => {

--- a/tests/browser/plugins.test.js
+++ b/tests/browser/plugins.test.js
@@ -139,6 +139,14 @@ describe("Plugins", function() {
         }, `FatalError: [registerPlugin] Invalid plugin name "pluginTest".`);
 
         await utils.assertThrowsAsync(() => {
+            Wendigo.registerPlugin("assert", PluginTest);
+        }, `FatalError: [registerPlugin] Invalid plugin name "assert".`);
+
+        await utils.assertThrowsAsync(() => {
+            Wendigo.registerPlugin("page", PluginTest);
+        }, `FatalError: [registerPlugin] Invalid plugin name "page".`);
+
+        await utils.assertThrowsAsync(() => {
             Wendigo.registerPlugin("", PluginTest);
         }, `FatalError: [registerPlugin] Plugin requires a name.`);
     });
@@ -181,8 +189,7 @@ describe("Plugins", function() {
         await browser.close();
     });
 
-    // Tests Issue #288
-    it.skip("Register Plugin With Function Assertion And Not Assertion", async() => {
+    it("Register Plugin With Function Assertion And Not Assertion", async() => {
         Wendigo.registerPlugin("pluginTest", null, {
             assert: () => {
                 return "ok";

--- a/tests/browser/wait_for.test.js
+++ b/tests/browser/wait_for.test.js
@@ -131,4 +131,24 @@ describe("Wait For", function() {
             await browser.waitForText("Off", 10);
         }, `TimeoutError: [waitForText] Waiting for text "Off", timeout of 10ms exceeded.`);
     });
+
+    // Test #305
+    it.skip("Wait For Url Using Regexp", async() => {
+        await browser.open(configUrls.index);
+        await browser.click("a");
+        await utils.assertThrowsAsync(async() => {
+            await browser.waitForUrl(/not-a-web/, 10);
+        }, `TimeoutError: [waitForUrl] Waiting for url "/not-a-web/", timeout of 10ms exceeded.`);
+
+        await browser.assert.not.title("Index Test");
+        await browser.assert.url(configUrls.simple);
+    });
+
+    it.skip("Wait For Url Regexp Timeout", async() => {
+        await browser.open(configUrls.index);
+        await browser.click("a");
+        await browser.waitForUrl(/html_simple/);
+        await browser.assert.not.title("Index Test");
+        await browser.assert.url(configUrls.simple);
+    });
 });

--- a/tests/browser/wait_for.test.js
+++ b/tests/browser/wait_for.test.js
@@ -132,23 +132,27 @@ describe("Wait For", function() {
         }, `TimeoutError: [waitForText] Waiting for text "Off", timeout of 10ms exceeded.`);
     });
 
-    // Test #305
-    it.skip("Wait For Url Using Regexp", async() => {
-        await browser.open(configUrls.index);
-        await browser.click("a");
-        await utils.assertThrowsAsync(async() => {
-            await browser.waitForUrl(/not-a-web/, 10);
-        }, `TimeoutError: [waitForUrl] Waiting for url "/not-a-web/", timeout of 10ms exceeded.`);
-
-        await browser.assert.not.title("Index Test");
-        await browser.assert.url(configUrls.simple);
-    });
-
-    it.skip("Wait For Url Regexp Timeout", async() => {
+    it("Wait For Url Regexp", async() => {
         await browser.open(configUrls.index);
         await browser.click("a");
         await browser.waitForUrl(/html_simple/);
         await browser.assert.not.title("Index Test");
         await browser.assert.url(configUrls.simple);
+    });
+
+    it("Wait For Url Regexp Timeout", async() => {
+        await browser.open(configUrls.index);
+        await browser.click("a");
+        await utils.assertThrowsAsync(async() => {
+            await browser.waitForUrl(/not-a-web/, 10);
+        }, `TimeoutError: [waitForUrl] Waiting for url "/not-a-web/", timeout of 10ms exceeded.`);
+    });
+
+    it("Wait For Url Invalid Parameter", async() => {
+        await browser.open(configUrls.index);
+        await browser.click("a");
+        await utils.assertThrowsAsync(async() => {
+            await browser.waitForUrl("", 10);
+        }, `Error: [waitForUrl] Invalid parameter url.`);
     });
 });

--- a/tests/browser_modules/request_mock_object.test.js
+++ b/tests/browser_modules/request_mock_object.test.js
@@ -182,4 +182,20 @@ describe("Requests Mock Object", function() {
             }, "postbody fails");
         }, `[assert.postBody] postbody fails`);
     });
+
+    it("Mock With Trigger And Response", async() => {
+        const response = Object.assign({
+            auto: false
+        }, mockResponse);
+        const mock = browser.requests.mock(configUrls.api, response);
+        assert.strictEqual(mock.auto, false);
+        await browser.clickText("click me");
+        await browser.assert.not.text("#result", "MOCK");
+        mock.trigger({
+            body: {result: "MOCK2"}
+        });
+        await browser.wait(20);
+        await browser.assert.text("#result", "MOCK2");
+        assert.strictEqual(mock._response.body, JSON.stringify({result: "MOCK"}));
+    });
 });

--- a/tests/browser_modules/request_redirect.test.js
+++ b/tests/browser_modules/request_redirect.test.js
@@ -8,7 +8,7 @@ describe("Requests Redirect", function() {
     let browser;
 
     beforeEach(async() => {
-        browser = await Wendigo.createBrowser({log: true});
+        browser = await Wendigo.createBrowser();
         await browser.open(configUrls.requestsFake);
     });
 


### PR DESCRIPTION
* Support for an object with assert and not functions for a plugin
* RegExp support for waitForUrl
* Mock.trigger accepts an optional response
* Browser.evaluate now supports returning DOMElements
* Puppeteer updated to 1.14.0
* Cookies is now fully implemented as a plugin
* ElementFromPoint not returns null if no element is found