### PR TITLE
Statement "instanceof RegExp" can be inconsistent

### DIFF
--- a/lib/browser/mixins/browser_wait.ts
+++ b/lib/browser/mixins/browser_wait.ts
@@ -1,3 +1,4 @@
+import isRegExp from 'lodash.isregexp';
 import BrowserNavigation from './browser_navigation';
 import DomElement from '../../models/dom_element';
 import { TimeoutError, WendigoError, QueryError } from '../../models/errors';
@@ -62,7 +63,7 @@ export default abstract class BrowserWait extends BrowserNavigation {
         timeout = this._getTimeout(timeout);
         if (!url) return Promise.reject(new WendigoError("waitForUrl", `Invalid parameter url.`));
         let parsedUrl: string | RegExp | { source: string, flags: string } = url;
-        if (url instanceof RegExp) {
+        if (isRegExp(url)) {
             parsedUrl = {
                 source: url.source,
                 flags: url.flags

--- a/lib/modules/requests/request_filter.ts
+++ b/lib/modules/requests/request_filter.ts
@@ -1,9 +1,10 @@
+import isRegExp from 'lodash.isregexp';
 import { Request, ResourceType } from '../../puppeteer_wrapper/puppeteer_types';
 import { matchText } from '../../utils/utils';
 import { ExpectedHeaders } from './types';
 
 function processBody(body: string | RegExp | object): string | RegExp {
-    if (typeof body === 'object' && !(body instanceof RegExp)) {
+    if (typeof body === 'object' && !isRegExp(body)) {
         return JSON.stringify(body);
     } else return body;
 }

--- a/lib/modules/requests/request_mock.ts
+++ b/lib/modules/requests/request_mock.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import isRegExp from 'lodash.isregexp';
 import { URL } from 'url';
 import { Request } from '../../puppeteer_wrapper/puppeteer_types';
 
@@ -178,7 +179,7 @@ export default class RequestMock implements RequestMockInterface {
     }
 
     private _parseUrlQueryString(url: string | RegExp): { [s: string]: string; } | undefined {
-        if (url instanceof RegExp) return undefined;
+        if (isRegExp(url)) return undefined;
         else {
             const parsedUrl = new URL(url);
             if (parsedUrl.search) {
@@ -188,7 +189,7 @@ export default class RequestMock implements RequestMockInterface {
     }
 
     private _parseUrl(url: string | RegExp): string | RegExp {
-        if (url instanceof RegExp) {
+        if (isRegExp(url)) {
             return url;
         } else {
             const parsedUrl = new URL(url);

--- a/lib/modules/requests/request_mocker.ts
+++ b/lib/modules/requests/request_mocker.ts
@@ -1,3 +1,4 @@
+import isRegExp from 'lodash.isregexp';
 import { URL } from 'url';
 import { parseQueryString, compareObjects, matchText } from '../../utils/utils';
 import RequestMock from './request_mock';
@@ -91,7 +92,7 @@ export default class RequestMocker {
         if (existsPriority !== null) return existsPriority;
         const methodPriority = this._checkElementPriority(m1.method, m2.method);
         if (methodPriority !== null) return methodPriority;
-        const urlPriority = this._checkElementPriority(!(m1.url instanceof RegExp), !(m2.url instanceof RegExp));
+        const urlPriority = this._checkElementPriority(!isRegExp(m1.url), !isRegExp(m2.url));
         if (urlPriority !== null) return urlPriority;
         return Boolean(this._checkElementPriority(m1.queryString, m2.queryString));
     }

--- a/lib/puppeteer_wrapper/puppeteer_utils.ts
+++ b/lib/puppeteer_wrapper/puppeteer_utils.ts
@@ -1,3 +1,4 @@
+import isRegExp from 'lodash.isregexp';
 import { ConsoleMessage, JSHandle } from './puppeteer_types';
 
 export async function stringifyLogText(log: ConsoleMessage): Promise<string> {
@@ -11,7 +12,7 @@ export async function stringifyLogText(log: ConsoleMessage): Promise<string> {
 
 function stringifyLogArg(arg: JSHandle): Promise<string> {
     return arg.executionContext().evaluate(element => {
-        if (typeof element === 'object' && !(element instanceof RegExp)) {
+        if (typeof element === 'object' && !isRegExp(element)) {
             try {
                 element = JSON.stringify(element);
             } catch (err) {

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,3 +1,4 @@
+import isRegExp from 'lodash.isregexp';
 import querystring from 'querystring';
 import { URL } from 'url';
 
@@ -19,7 +20,7 @@ export function isXPathQuery(s: string): boolean {
 }
 
 export function stringify(element: any): string {
-    if (typeof element === 'object' && !(element instanceof RegExp)) {
+    if (typeof element === 'object' && !isRegExp(element)) {
         element = JSON.stringify(element);
     }
     return String(element);
@@ -46,7 +47,7 @@ export function promiseOr(promises: Array<Promise<any>>): Promise<any> {
 
 export function matchText(text: string | null | undefined, expected: string | RegExp): boolean {
     if (text === undefined || text === null) return false;
-    if (expected instanceof RegExp) {
+    if (isRegExp(expected)) {
         return expected.test(text);
     } else {
         return text === expected;

--- a/package.json
+++ b/package.json
@@ -43,9 +43,11 @@
   "dependencies": {
     "compositer": "^1.3.6",
     "is-class": "0.0.9",
+    "lodash.isregexp": "^4.0.1",
     "puppeteer": "~5.3.1"
   },
   "devDependencies": {
+    "@types/lodash.isregexp": "^4.0.6",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.5",
     "@types/puppeteer": "~3.0.2",

--- a/tests/browser/evaluate.test.js
+++ b/tests/browser/evaluate.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const isRegExp = require('lodash.isregexp');
 const Wendigo = require('../..');
 const DomElement = require('../../dist/lib/models/dom_element').default;
 const assert = require('assert');
@@ -54,7 +55,7 @@ describe("Evaluate", function() {
         const result = await browser.evaluate(() => {
             return /aba/g;
         });
-        assert.ok(result instanceof RegExp);
+        assert.ok(isRegExp(result));
         assert.strictEqual(result.source, "aba");
         assert.strictEqual(result.flags, "g");
     });


### PR DESCRIPTION
I was using node v15.0.1 on Windows 10 x64 with Jest, passing a RegExp to a Vm could cause a false on this changed statement.