### PR TITLE
Added defaultViewport to browser.open

### DIFF
--- a/lib/browser/browser_core.ts
+++ b/lib/browser/browser_core.ts
@@ -88,7 +88,14 @@ export default abstract class BrowserCore {
     @OverrideError()
     public async open(url: string, options?: OpenSettings): Promise<void> {
         this._loaded = false;
-        this._openSettings = Object.assign({}, defaultOpenOptions, options);
+        this._openSettings = Object.assign(
+            {},
+            defaultOpenOptions,
+            'defaultViewport' in this._settings ?
+                { viewport: this._settings.defaultViewport } :
+                {},
+            options
+        );
         url = this._processUrl(url);
         await this.setCache(this._cache);
         if (this._openSettings.queryString) {

--- a/lib/puppeteer_wrapper/puppeteer_page.ts
+++ b/lib/puppeteer_wrapper/puppeteer_page.ts
@@ -45,7 +45,7 @@ export default class PuppeteerPage {
     }
 
     public setViewport(config: ViewportOptions = {}): Promise<void> {
-        const finalConfig = Object.assign({}, this.page.viewport(), config) as Viewport;
+        const finalConfig = !config ? config : Object.assign({}, this.page.viewport(), config) as Viewport;
         return this.page.setViewport(finalConfig);
     }
 


### PR DESCRIPTION
It would be nice if Wendigo followed this same parameter of defaultViewport and the solution is very simple. Please pay attention that defaultViewport can be `null`, so `!!this._settings.defaultViewport` is not an option to validate.
https://github.com/puppeteer/puppeteer/blob/v5.4.1/docs/api.md#puppeteerconnectoptions